### PR TITLE
Remove redundant README generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,7 @@ language: perl
 matrix:
     fast_finish: true
 perl:
-   - '5.24'
-   - '5.22'
-   - '5.20'
-   - '5.18'
-   - '5.16'
-   - '5.14'
+   - '5.26'
 before_install:
    - git config --global user.name "TravisCI"
    - git config --global user.email $HOSTNAME":not-for-mail@travis-ci.org"

--- a/dist.ini
+++ b/dist.ini
@@ -12,7 +12,6 @@ except = t/rc/\.perl.*rc$
 [ManifestSkip]
 [MetaYAML]
 [License]
-[Readme]
 [MakeMaker]
 eumm_version = 6.48
 prereq_fatal = 1

--- a/t/boilerplate.t
+++ b/t/boilerplate.t
@@ -41,7 +41,7 @@ sub module_boilerplate_ok {
 TODO: {
   local $TODO = "Need to replace the boilerplate text";
 
-  not_in_file_ok(README =>
+  not_in_file_ok('README.md' =>
     "The README is used..."       => qr/The README is used/,
     "'version information here'"  => qr/to provide version information/,
   );


### PR DESCRIPTION
We already have a README.md so this unnecessary, and the test for this
breaks the ability to install this dist directly from git.